### PR TITLE
function js_import deprecated since nginx 0.4

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -60,6 +60,7 @@ data:
     function fetch_env(r) {
       return process.env.ENV;
     }
+    export default {fetch_app, fetch_env};
   nginx.conf: |
     load_module modules/ngx_http_js_module.so;
 
@@ -78,9 +79,9 @@ data:
 
 
     http {
-        js_include fetch_env.js;
-        js_set $app fetch_app;
-        js_set $env fetch_env;
+        js_import fetch_env_vars from fetch_env.js;
+        js_set $app fetch_env_vars.fetch_app;
+        js_set $env fetch_env_vars.fetch_env;
         include       /etc/nginx/mime.types;
         default_type  application/octet-stream;
 


### PR DESCRIPTION
utilisation de js_import en remplacement de js_include